### PR TITLE
Updated transaction and property handling for 2.0.0-M06 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
         <bundle.namespace>org.neo4j.server.authentication-extension</bundle.namespace>
 
         <!-- Jar Versions -->
-        <neo4j.version>2.0.0-M04</neo4j.version>
+        <neo4j.version>2.0.0-M06</neo4j.version>
         <jersey.version>1.9</jersey.version>
     </properties>
 
@@ -43,8 +43,8 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                  <source>1.6</source>
-                  <target>1.6</target>
+                  <source>1.7</source>
+                  <target>1.7</target>
                   <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>

--- a/src/main/java/org/neo4j/server/extension/auth/MultipleAuthenticationService.java
+++ b/src/main/java/org/neo4j/server/extension/auth/MultipleAuthenticationService.java
@@ -53,14 +53,14 @@ public class MultipleAuthenticationService implements AuthenticationService {
     }
 
     private String getCredentials(String cred) {
-        Transaction tx = graph.beginTx();
-        try {
+    	String credentials = "";
+        try (Transaction tx = graph.beginTx()) {
             PropertyContainer properties = getGraphProperties();
-            String credentials = (String) properties.getProperty(getUserKey(cred), "");
+            if (properties.hasProperty(getUserKey(cred))) {
+	           credentials = (String) properties.getProperty(getUserKey(cred));
+            }
             tx.success();
             return credentials;
-        } finally {
-            tx.finish();
         }
     }
 
@@ -74,8 +74,7 @@ public class MultipleAuthenticationService implements AuthenticationService {
     }
 
     public Map<String, Permission> getUsers() {
-        Transaction tx = graph.beginTx();
-        try {
+        try (Transaction tx = graph.beginTx()) {
             final Map<String, Permission> result = new HashMap<String, Permission>();
 
             PropertyContainer properties = getGraphProperties();
@@ -88,8 +87,6 @@ public class MultipleAuthenticationService implements AuthenticationService {
             }
             tx.success();
             return result;
-        } finally {
-            tx.finish();
         }
     }
 
@@ -103,8 +100,7 @@ public class MultipleAuthenticationService implements AuthenticationService {
     }
 
     public void setPermissionForUser(String user, Permission permission) {
-        Transaction transaction = graph.beginTx();
-        try {
+        try (Transaction transaction = graph.beginTx()) {
             PropertyContainer properties = getGraphProperties();
             String key = getUserKey(user);
             if (permission == Permission.NONE) {
@@ -113,10 +109,6 @@ public class MultipleAuthenticationService implements AuthenticationService {
                 properties.setProperty(key, permission.name());
             }
             transaction.success();
-        } catch (Exception e) {
-            transaction.failure();
-        } finally {
-            transaction.finish();
         }
     }
 


### PR DESCRIPTION
I've converted transactions to use the new AutoClosable interface, and slightly altered the property retrieval. Even with a default string supplied, getProperty on GraphPropertiesImpl now returns boolean false if the key isn't found (possible bug, unless I'm misunderstanding the expected behaviour?), meaning an extra check is required before the cast. 
